### PR TITLE
Event Emitter Fix

### DIFF
--- a/ios/ReactNativeLightning.m
+++ b/ios/ReactNativeLightning.m
@@ -38,15 +38,17 @@ RCT_EXTERN_METHOD(
                   body: (NSString *)body
                   )
 
-// Keep: Required for RN built in Event Emitter Calls.
 RCT_EXPORT_METHOD(
                   addListener : (NSString *)eventName
-                  )
+                  ) {
+    // Keep: Required for RN built in Event Emitter Calls.
+                  }
 
-// Keep: Required for RN built in Event Emitter Calls.
 RCT_EXPORT_METHOD(
                   removeListeners : (NSInteger)count
-                  )
+                  ) {
+    // Keep: Required for RN built in Event Emitter Calls.
+                  }
 @end
 
 //MARK: Events

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-lightning",
   "title": "React Native Lightning",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "React Native wrapper for Lndmobile",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -63,7 +63,7 @@
   "dependencies": {
     "base64-js": "^1.5.1",
     "protobufjs": "^6.10.2",
-    "react-native-fs": "^2.18.0",
+    "react-native-fs": "https://github.com/synonymdev/react-native-fs",
     "react-native-zip-archive": "^6.0.3"
   },
   "bugs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,10 +1688,9 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-native-fs@^2.18.0:
+"react-native-fs@https://github.com/synonymdev/react-native-fs":
   version "2.18.0"
-  resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.18.0.tgz#987b99cc90518ef26663a8d60e62104694b41c21"
-  integrity sha512-9iQhkUNnN2JNED0in06JwZy88YEVyIGKWz4KLlQYxa5Y2U0U2AZh9FUHtA04oWj+xt2LlHh0LFPCzhmNsAsUDg==
+  resolved "https://github.com/synonymdev/react-native-fs#0b1d2eb793319acb8d6864cc6e32ee0ce342afa8"
   dependencies:
     base-64 "^0.1.0"
     utf8 "^3.0.0"


### PR DESCRIPTION
 - Updated react-native-fs dependency in package.json and updated yarn.lock accordingly.
 - Updated addListener & removeListeners methods in ReactNativeLightning.m.
 - Bumped version to 0.0.37 in package.json.
 - This addresses #28